### PR TITLE
Include value of newly discovered node in the reward #18

### DIFF
--- a/cyberbattle/__init__.py
+++ b/cyberbattle/__init__.py
@@ -43,7 +43,7 @@ register(
     cyberbattle_env_identifiers=toy_ctf.ENV_IDENTIFIERS,
     entry_point='cyberbattle._env.cyberbattle_toyctf:CyberBattleToyCtf',
     kwargs={'defender_agent': None,
-            'attacker_goal': AttackerGoal(reward=889),
+            'attacker_goal': AttackerGoal(own_atleast=6),
             'defender_goal': DefenderGoal(eviction=True)
             },
     # max_episode_steps=2600,
@@ -67,7 +67,7 @@ register(
     entry_point='cyberbattle._env.cyberbattle_chain:CyberBattleChain',
     kwargs={'size': 4,
             'defender_agent': None,
-            'attacker_goal': AttackerGoal(reward=2200),
+            'attacker_goal': AttackerGoal(own_atleast_percent=1.0),
             'defender_goal': DefenderGoal(eviction=True),
             'winning_reward': 5000.0,
             'losing_reward': 0.0

--- a/cyberbattle/_env/cyberbattle_env_test.py
+++ b/cyberbattle/_env/cyberbattle_env_test.py
@@ -90,14 +90,13 @@ def test_step_after_done() -> None:
         {'connect': np.array([8, 10, 3, 9])},              # done=False, r=100.0
         {'local_vulnerability': np.array([10, 4])},        # done=False, r=49.0
         {'local_vulnerability': np.array([8, 1])},         # done=False, r=49.0
-        {'connect': np.array([7, 11, 2, 10])},             # done=False, r=1000.0
-        {'connect': np.array([5, 10, 3, 9])},              # done=True, r=5000.0
+        {'connect': np.array([7, 11, 2, 10])},             # done=True, r=1000.0
 
         # this is one too many (after done)
         {'connect': np.array([10, 5, 2, 4])},              # done=True, r=5000.0
     ]
 
-    env = gym.make('CyberBattleChain-v0', size=10, attacker_goal=AttackerGoal(reward=4000))
+    env = gym.make('CyberBattleChain-v0', size=10, attacker_goal=AttackerGoal(own_atleast_percent=1.0))
 
     for a in actions[:-1]:
         env.step(a)

--- a/cyberbattle/_env/cyberbattle_env_test.py
+++ b/cyberbattle/_env/cyberbattle_env_test.py
@@ -35,71 +35,72 @@ def test_few_gym_iterations() -> None:
 
 def test_step_after_done() -> None:
     actions = [
-        {'local_vulnerability': np.array([0, 1])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([0, 1, 0])},     # done=False, r=45.0
-        {'connect': np.array([0, 1, 2, 0])},               # done=False, r=100.0
-        {'local_vulnerability': np.array([1, 3])},         # done=False, r=49.0
-        {'connect': np.array([0, 2, 3, 1])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([1, 2, 1])},     # done=False, r=49.0
-        {'remote_vulnerability': np.array([1, 2, 0])},     # done=False, r=49.0
-        {'remote_vulnerability': np.array([2, 1, 1])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([1, 0])},         # done=False, r=49.0
-        {'local_vulnerability': np.array([1, 1])},         # done=False, r=40.0
-        {'local_vulnerability': np.array([2, 1])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([2, 3, 0])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([2, 4])},         # done=False, r=49.0
-        {'connect': np.array([0, 3, 2, 2])},               # done=False, r=100.0
-        {'local_vulnerability': np.array([3, 3])},         # done=False, r=49.0
-        {'local_vulnerability': np.array([3, 0])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([0, 4, 1])},     # done=False, r=49.0
-        {'local_vulnerability': np.array([3, 1])},         # done=False, r=40.0
-        {'connect': np.array([2, 4, 3, 3])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([1, 3, 1])},     # done=False, r=45.0
-        {'remote_vulnerability': np.array([1, 4, 0])},     # done=False, r=49.0
-        {'local_vulnerability': np.array([4, 1])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([0, 5, 0])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([4, 4])},         # done=False, r=49.0
-        {'connect': np.array([3, 5, 2, 4])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([2, 5, 1])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([5, 3])},         # done=False, r=49.0
-        {'connect': np.array([2, 6, 3, 5])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([4, 6, 1])},     # done=False, r=49.0
-        {'local_vulnerability': np.array([5, 0])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([4, 6, 0])},     # done=False, r=49.0
-        {'local_vulnerability': np.array([5, 1])},         # done=False, r=40.0
-        {'local_vulnerability': np.array([6, 1])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([6, 7, 0])},     # done=False, r=45.0
-        {'remote_vulnerability': np.array([0, 7, 1])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([6, 4])},         # done=False, r=49.0
-        {'connect': np.array([4, 7, 2, 6])},               # done=False, r=100.0
-        {'local_vulnerability': np.array([7, 3])},         # done=False, r=49.0
-        {'connect': np.array([0, 8, 3, 7])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([0, 8, 0])},     # done=False, r=49.0
-        {'local_vulnerability': np.array([7, 0])},         # done=False, r=49.0
-        {'local_vulnerability': np.array([8, 4])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([3, 9, 1])},     # done=False, r=45.0
-        {'connect': np.array([3, 9, 2, 8])},               # done=False, r=100.0
-        {'remote_vulnerability': np.array([4, 9, 0])},     # done=False, r=45.0
-        {'local_vulnerability': np.array([9, 0])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([3, 8, 1])},     # done=False, r=49.0
-        {'remote_vulnerability': np.array([6, 10, 0])},    # done=False, r=49.0
-        {'local_vulnerability': np.array([9, 1])},         # done=False, r=40.0
-        {'local_vulnerability': np.array([9, 3])},         # done=False, r=49.0
-        {'remote_vulnerability': np.array([8, 10, 1])},    # done=False, r=49.0
-        {'local_vulnerability': np.array([7, 1])},         # done=False, r=40.0
-        {'connect': np.array([8, 10, 3, 9])},              # done=False, r=100.0
-        {'local_vulnerability': np.array([10, 4])},        # done=False, r=49.0
-        {'local_vulnerability': np.array([8, 1])},         # done=False, r=49.0
-        {'connect': np.array([7, 11, 2, 10])},             # done=True, r=1000.0
+        {'local_vulnerability': np.array([0, 1])},  # done=False r=9.0
+        {'remote_vulnerability': np.array([0, 1, 0])},  # done=False r=4.0
+        {'connect': np.array([0, 1, 2, 0])},  # done=False r=100.0
+        {'local_vulnerability': np.array([1, 3])},  # done=False r=9.0
+        {'connect': np.array([0, 2, 3, 1])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([1, 2, 1])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([1, 2, 0])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([2, 1, 1])},  # done=False r=2.0
+        {'local_vulnerability': np.array([1, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([1, 1])},  # done=False r=0.0
+        {'local_vulnerability': np.array([2, 1])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([2, 3, 0])},  # done=False r=4.0
+        {'local_vulnerability': np.array([2, 4])},  # done=False r=9.0
+        {'connect': np.array([0, 3, 2, 2])},  # done=False r=100.0
+        {'local_vulnerability': np.array([3, 3])},  # done=False r=9.0
+        {'local_vulnerability': np.array([3, 0])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([0, 4, 1])},  # done=False r=8.0
+        {'local_vulnerability': np.array([3, 1])},  # done=False r=0.0
+        {'connect': np.array([2, 4, 3, 3])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([1, 3, 1])},  # done=False r=2.0
+        {'remote_vulnerability': np.array([1, 4, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([4, 1])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([0, 5, 0])},  # done=False r=4.0
+        {'local_vulnerability': np.array([4, 4])},  # done=False r=9.0
+        {'connect': np.array([3, 5, 2, 4])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([2, 5, 1])},  # done=False r=2.0
+        {'local_vulnerability': np.array([5, 3])},  # done=False r=9.0
+        {'connect': np.array([2, 6, 3, 5])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([4, 6, 1])},  # done=False r=6.0
+        {'local_vulnerability': np.array([5, 0])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([4, 6, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([5, 1])},  # done=False r=0.0
+        {'local_vulnerability': np.array([6, 1])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([6, 7, 0])},  # done=False r=4.0
+        {'remote_vulnerability': np.array([0, 7, 1])},  # done=False r=2.0
+        {'local_vulnerability': np.array([6, 4])},  # done=False r=9.0
+        {'connect': np.array([4, 7, 2, 6])},  # done=False r=100.0
+        {'local_vulnerability': np.array([7, 3])},  # done=False r=9.0
+        {'connect': np.array([0, 8, 3, 7])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([0, 8, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([7, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([8, 4])},  # done=False r=9.0
+        {'remote_vulnerability': np.array([3, 9, 1])},  # done=False r=2.0
+        {'connect': np.array([3, 9, 2, 8])},  # done=False r=100.0
+        {'remote_vulnerability': np.array([4, 9, 0])},  # done=False r=2.0
+        {'local_vulnerability': np.array([9, 0])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([3, 8, 1])},  # done=False r=6.0
+        {'remote_vulnerability': np.array([6, 10, 0])},  # done=False r=6.0
+        {'local_vulnerability': np.array([9, 1])},  # done=False r=0.0
+        {'local_vulnerability': np.array([9, 3])},  # done=False r=9.0
+        {'remote_vulnerability': np.array([8, 10, 1])},  # done=False r=8.0
+        {'local_vulnerability': np.array([7, 1])},  # done=False r=0.0
+        {'connect': np.array([8, 10, 3, 9])},  # done=False r=100.0
+        {'local_vulnerability': np.array([10, 4])},  # done=False r=9.0
+        {'local_vulnerability': np.array([8, 1])},  # done=False r=6.0
+        {'connect': np.array([7, 11, 2, 10])},  # done=True r=5000.0
 
         # this is one too many (after done)
-        {'connect': np.array([10, 5, 2, 4])},              # done=True, r=5000.0
+        {'connect': np.array([10, 5, 2, 4])},
     ]
 
     env = gym.make('CyberBattleChain-v0', size=10, attacker_goal=AttackerGoal(own_atleast_percent=1.0))
 
     for a in actions[:-1]:
-        env.step(a)
+        observation, reward, done, info = env.step(a)
+        print(f"{a}, # done={done} r={reward}")
 
     with pytest.raises(RuntimeError, match=r'new episode must be started with env\.reset\(\)'):
         env.step(actions[-1])

--- a/cyberbattle/agents/baseline/notebooks/notebook_all_agents_benchmark.py
+++ b/cyberbattle/agents/baseline/notebooks/notebook_all_agents_benchmark.py
@@ -42,7 +42,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.ERROR, format="%(levelname)
 cyberbattlechain_10 = gym.make(
     'CyberBattleChain-v0',
     size=10,
-    attacker_goal=cyberbattle_env.AttackerGoal(reward=4000, own_atleast_percent=1.0)
+    attacker_goal=cyberbattle_env.AttackerGoal(own_atleast_percent=1.0)
 )
 
 cyberbattlechain_10.environment

--- a/cyberbattle/agents/baseline/notebooks/notebook_dql.py
+++ b/cyberbattle/agents/baseline/notebooks/notebook_dql.py
@@ -43,9 +43,9 @@ torch.cuda.is_available()
 # pio.orca.config.use_xvfb = True
 # pio.orca.config.save()
 # %%
-cyberbattlechain_4 = gym.make('CyberBattleChain-v0', size=4, attacker_goal=cyberbattle_env.AttackerGoal(reward=2180))
-cyberbattlechain_10 = gym.make('CyberBattleChain-v0', size=10, attacker_goal=cyberbattle_env.AttackerGoal(reward=4000))
-cyberbattlechain_20 = gym.make('CyberBattleChain-v0', size=20, attacker_goal=cyberbattle_env.AttackerGoal(reward=7000))
+cyberbattlechain_4 = gym.make('CyberBattleChain-v0', size=4, attacker_goal=cyberbattle_env.AttackerGoal(own_atleast_percent=1.0))
+cyberbattlechain_10 = gym.make('CyberBattleChain-v0', size=10, attacker_goal=cyberbattle_env.AttackerGoal(own_atleast_percent=1.0))
+cyberbattlechain_20 = gym.make('CyberBattleChain-v0', size=20, attacker_goal=cyberbattle_env.AttackerGoal(own_atleast_percent=1.0))
 
 ep = w.EnvironmentBounds.of_identifiers(
     maximum_total_credentials=22,

--- a/cyberbattle/agents/baseline/notebooks/notebook_withdefender.py
+++ b/cyberbattle/agents/baseline/notebooks/notebook_withdefender.py
@@ -32,7 +32,6 @@ logging.basicConfig(stream=sys.stdout, level=logging.ERROR, format="%(levelname)
 cyberbattlechain_defender = gym.make('CyberBattleChain-v0',
                                      size=10,
                                      attacker_goal=AttackerGoal(
-                                         # reward=2180,
                                          own_atleast=0,
                                          own_atleast_percent=1.0
                                      ),

--- a/cyberbattle/simulation/actions_test.py
+++ b/cyberbattle/simulation/actions_test.py
@@ -277,7 +277,7 @@ def test_exploit_remote_vulnerability(actions_on_simple_environment: Fixture) ->
     # test a valid and functional one.
     result = actions_on_simple_environment.exploit_remote_vulnerability('a', 'c', "RDPBF")
     assert isinstance(result.outcome, model.LateralMove)
-    assert result.reward <= actions.SUCCEEDED_ATTACK_REWARD - 1
+    assert result.reward <= node.value - 1
 
 
 def test_exploit_local_vulnerability(actions_on_simple_environment: Fixture) -> None:

--- a/cyberbattle/simulation/commandcontrol_test.py
+++ b/cyberbattle/simulation/commandcontrol_test.py
@@ -72,6 +72,6 @@ def test_toyctf() -> None:
 
     reward = command.total_reward()
     print('Total reward ' + str(reward))
-    assert reward == 759.0
+    assert reward == 269.0
     assert github is not None
     pass

--- a/cyberbattle/simulation/commandcontrol_test.py
+++ b/cyberbattle/simulation/commandcontrol_test.py
@@ -72,6 +72,6 @@ def test_toyctf() -> None:
 
     reward = command.total_reward()
     print('Total reward ' + str(reward))
-    assert reward == 269.0
+    assert reward == 344.0
     assert github is not None
     pass


### PR DESCRIPTION
With this change, in addition to the fixed reward per successful executed attack (or penalty for executing the same action multiple times) the reward also accounts for the intrinsic value of _newly_ discovered nodes and number of _newly_ discovered credentials and node properties.

