### PR TITLE
fixed an error in the function create_random_firewall_configuration() in model.py

### DIFF
--- a/cyberbattle/simulation/model.py
+++ b/cyberbattle/simulation/model.py
@@ -491,13 +491,13 @@ def assign_random_labels(
                 FirewallRule(port=p, permission=RulePermission.ALLOW)
                 for p in
                 random.sample(
-                    identifiers.properties,
-                    k=random.randint(0, len(identifiers.properties)))],
+                    identifiers.ports,
+                    k=random.randint(0, len(identifiers.ports)))],
             incoming=[
                 FirewallRule(port=p, permission=RulePermission.ALLOW)
                 for p in random.sample(
-                    identifiers.properties,
-                    k=random.randint(0, len(identifiers.properties)))])
+                    identifiers.ports,
+                    k=random.randint(0, len(identifiers.ports)))])
 
     def create_random_properties() -> List[PropertyName]:
         return list(random.sample(


### PR DESCRIPTION
In "model.py" module, the firewall rules are to constructed by randomly choosing from the list of ports in the dict "Identifiers". But in the function "create_random_firewall_configuration()", the firewall rules are constructed by choosing random properties instead of ports. This error is noticed and fixed.