### PR TITLE
Fixed typos in Markdown files and Jupyter notebook

### DIFF
--- a/cyberbattle/agents/baseline/run.py
+++ b/cyberbattle/agents/baseline/run.py
@@ -43,7 +43,7 @@ parser.add_argument('--reward_goal', default=2180, type=int,
 parser.add_argument('--ownership_goal', default=1.0, type=float,
                     help='percentage of network nodes to own for the attacker to reach its goal')
 
-parser.add_argument('--rewardplot_with', default=80, type=int,
+parser.add_argument('--rewardplot_width', default=80, type=int,
                     help='width of the reward plot (values are averaged across iterations to fit in the desired width)')
 
 parser.add_argument('--chain_size', default=4, type=int,
@@ -87,7 +87,7 @@ dqn_learning_run = learner.epsilon_greedy_search(
     episode_count=args.training_episode_count,
     iteration_count=args.iteration_count,
     epsilon=0.90,
-    render=False,
+    render=True,
     # epsilon_multdecay=0.75,  # 0.999,
     epsilon_exponential_decay=5000,  # 10000
     epsilon_minimum=0.10,

--- a/docs/quickintro.md
+++ b/docs/quickintro.md
@@ -33,6 +33,7 @@ using RL terminology.
 Our network __environment__ is given by a directed annotated graph where
 nodes represent computers and edges represent knowledge of other nodes or communication taking place between nodes.
 ![image.png](.attachments/image-377114ff-cdb7-4bee-88da-cac09640f661.png)
+
 Here you can see a toy example of network
 with machines running different OSes, software.
 Each machine has properties, a value, and suffers from pre-assigned vulnerabilities.
@@ -106,7 +107,7 @@ Consider as a toy example, the 'Capture the flag' game played on the computer sy
 
 ![image.png](.attachments/image-8cfbbc68-6db1-42f2-867d-5502ff56c4b3.png)
 
-Each graph node is a computing resource with implanted security flaws and vulnerabilities such as reused password, insucure passwords, leaked access tokens, misconfigured Access control, browsable direcotries, and so on.  The goal of the attacker is to take ownership of critical nodes in the graph (e.g., Azure and Sharepoint resources). For simplicity we assume that no defender is present and that the game is fully static (no external events between two action of the attacker).
+Each graph node is a computing resource with implanted security flaws and vulnerabilities such as reused password, insecure passwords, leaked access tokens, misconfigured Access control, browsable directories, and so on.  The goal of the attacker is to take ownership of critical nodes in the graph (e.g., Azure and Sharepoint resources). For simplicity we assume that no defender is present and that the game is fully static (no external events between two action of the attacker).
 
 We formally defined this network in Python code at [toy_ctf.py](../cyberbattle/samples/toyctf/toy_ctf.py).
 Here is a snippet of the code showing how we define the node `Website` with its properties, firewall configuration and implanted vulnerabilities:
@@ -152,7 +153,7 @@ nodes = {
 
 ### Interactive play with ToyCTF
 
-You can play the simulation interactively using the Jupyter notebook located at [toyctf-blank.ipynb](notebooks/toyctf-blank.ipynb). Try the following commands:
+You can play the simulation interactively using the Jupyter notebook located at [toyctf-blank.ipynb](../notebooks/toyctf-blank.ipynb). Try the following commands:
 
 ```python
 env.plot_environment_graph()

--- a/docs/quickintro.md
+++ b/docs/quickintro.md
@@ -179,11 +179,10 @@ The plot function displays the subset of the network explorsed so far. After a f
    ![image.png](.attachments/image-4fd79f98-36b2-45ae-82e4-2631aacda090.png)
 
 ### Solution
-The fully solved game is provided in the notebook [toyctf-solved.ipynb](notebooks/toyctf-solved.ipynb).
+The fully solved game is provided in the notebook [toyctf-solved.ipynb](../notebooks/toyctf-solved.ipynb).
 
 ### A random agent playing ToyCTF
-
-The notebook [toyctf-random.ipynb](notebooks/toyctf-random.ipynb)
+The notebook [toyctf-random.ipynb](../notebooks/toyctf-random.ipynb)
 runs a random agent on the ToyCTF enviornment: at each step, the agent
 picks an action at random from the action space.
 

--- a/notebooks/toyctf-blank.ipynb
+++ b/notebooks/toyctf-blank.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a blank instantiaion of the Capture The Flag network to be play interactively by a human player (not via the gym envrionment).\n",
+    "This is a blank instantiaion of the Capture The Flag network to be played interactively by a human player (not via the gym envrionment).\n",
     "The interface exposed to the attacker is given by the following commands:\n",
     "    - c2.print_all_attacks()\n",
     "    - c2.run_attack(node, attack_id)\n",
@@ -79,7 +79,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": ""
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I have not changed any functionality. the only modification is the fix of typos for few words that were misspelled. In addition, clicking the link in the MD files in Vscode would yield an error because the link locations were incorrect, and I've fixed few of those.