### PR TITLE
Fix two bugs caught by pyright

### DIFF
--- a/cyberbattle/simulation/commandcontrol_test.py
+++ b/cyberbattle/simulation/commandcontrol_test.py
@@ -72,6 +72,6 @@ def test_toyctf() -> None:
 
     reward = command.total_reward()
     print('Total reward ' + str(reward))
-    assert reward == 244.0
+    assert reward == 289.0
     assert github is not None
     pass

--- a/cyberbattle/simulation/model.py
+++ b/cyberbattle/simulation/model.py
@@ -27,7 +27,7 @@ formally defined by:
 from datetime import datetime, time
 from typing import NamedTuple, List, Dict, Optional, Union, Tuple, Iterator
 import dataclasses
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import matplotlib.pyplot as plt  # type:ignore
 from enum import Enum, IntEnum
 from boolean import boolean
@@ -249,7 +249,8 @@ class RulePermission(Enum):
     BLOCK = 1
 
 
-class FirewallRule(NamedTuple):
+@dataclass(frozen=True)
+class FirewallRule:
     """A firewall rule"""
     # A port name
     port: PortName
@@ -259,7 +260,8 @@ class FirewallRule(NamedTuple):
     reason: str = ""
 
 
-class FirewallConfiguration(NamedTuple):
+@dataclass
+class FirewallConfiguration:
     """Firewall configuration on a given node.
     Determine if traffic should be allowed or specifically blocked
     on a given port for outgoing and incoming traffic.
@@ -270,16 +272,16 @@ class FirewallConfiguration(NamedTuple):
     are assumed to be blocked. (Adding an explicit block rule
     can still be useful to give a reason for the block.)
     """
-    outgoing: List[FirewallRule] = [
+    outgoing: List[FirewallRule] = field(repr=True, default_factory=lambda: [
         FirewallRule("RDP", RulePermission.ALLOW),
         FirewallRule("SSH", RulePermission.ALLOW),
         FirewallRule("HTTPS", RulePermission.ALLOW),
-        FirewallRule("HTTP", RulePermission.ALLOW)]
-    incoming: List[FirewallRule] = [
+        FirewallRule("HTTP", RulePermission.ALLOW)])
+    incoming: List[FirewallRule] = field(repr=True, default_factory=lambda: [
         FirewallRule("RDP", RulePermission.ALLOW),
         FirewallRule("SSH", RulePermission.ALLOW),
         FirewallRule("HTTPS", RulePermission.ALLOW),
-        FirewallRule("HTTP", RulePermission.ALLOW)]
+        FirewallRule("HTTP", RulePermission.ALLOW)])
 
 
 class MachineStatus(Enum):

--- a/notebooks/run_all.sh
+++ b/notebooks/run_all.sh
@@ -6,6 +6,12 @@ run () {
 }
 
 mkdir output -p
+
+run notebook_benchmark-toyctf
+run notebook_benchmark-chain
+run notebook_benchmark-tiny
+run notebook_dql_transfer
+
 run c2_interactive_interface
 run chainnetwork-optionwrapper
 run chainnetwork-random
@@ -13,3 +19,9 @@ run randomnetwork
 run toyctf-blank
 run toyctf-random
 run toyctf-solved
+
+run dql_active_directory
+run notebook_randlookups
+run notebook_tabularq
+run notebook_withdefender
+run random_active_directory


### PR DESCRIPTION
- Make `FirewallConfiguration` dataclass and `FirewallRule` frozen dataclass
- Boolean value not properly returned by __mark_discovered_nodes
- discovered nodes values should not be added to the reward unless the nodes just got owned