### PR TITLE
Fix python venv creation in init.sh and pip deps installation in install-pythonpackages.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -107,7 +107,7 @@ else
         python -m pip install --user virtualenv
 
         # Create a virtual environment
-        python -m venv venv
+        python -m virtualenv --always-copy --python=python3.9 venv
 
         source venv/bin/activate
     fi

--- a/install-pythonpackages.sh
+++ b/install-pythonpackages.sh
@@ -13,7 +13,7 @@ export MPLLOCALFREETYPE=1
 $PYTHON -m pip install --upgrade pip
 $PYTHON -m pip install --upgrade setuptools==65.5.0 # specific version needed for gym==0.21.0
 $PYTHON -m pip install --upgrade distlib
-$PYTHON -m pip install wheel
+$PYTHON -m pip install wheel==0.38.4 # specific version needed for gym==0.21.0
 $PYTHON -m pip install -e .
 $PYTHON -m pip install -e .[dev]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ numpy==1.23.0
 boolean.py==4.0
 networkx==2.8.6
 pyyaml~=6.0
-setuptools~=65.5.1
+setuptools~=65.5.0
+wheel~=0.38.0
 matplotlib~=3.6.0
 plotly~=4.11.0
 tabulate~=0.8.7


### PR DESCRIPTION
## TLDR
- Changes on `init.sh` is to solve an issue that couldn't create a python virtual environment.
- Change on `install-pythonpackages.sh` and `requirements.txt` is to solve an issue that couldn't install `gym==0.21.0`

Tested on both Ubuntu 22.04 (jammy) and Ubuntu 20.04 (focal).

### Code changes on init.sh

Both on Ubuntu 22.04 (jammy) and Ubuntu 20.04 (focal), I encountered an issue while running `init.sh`
```
Error: Command '['$HOME/$USER/CyberBattleSim/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
```
It seems `python -m venv venv` didn't create a virtual environment as expected.

Since we already installed `virtualenv` 
https://github.com/microsoft/CyberBattleSim/blob/bb9f70116f9252feebcefc6de5f000a26e955798/init.sh#L106-L107

I change to use `virtualenv` to create a virtual environment, and it works.


### Code changes on install-pythonpackages.sh 
After resolving the issue above, the environment was set up perfectly on Ubuntu 20.04 (focal). But I found gym==0.21.0 couldn't be installed on Ubuntu 22.04.
The outputs were like
```
Collecting gym==0.21.0
  Using cached gym-0.21.0.tar.gz (1.5 MB)
  Preparing metadata (setup.py) ... done
Collecting numpy>=1.18.0 (from gym==0.21.0)
  Downloading numpy-1.24.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.3/17.3 MB 12.5 MB/s eta 0:00:00
Collecting cloudpickle>=1.2.0 (from gym==0.21.0)
  Using cached cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Building wheels for collected packages: gym
  Building wheel for gym (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─
  ...
 raise InvalidRequirement(str(e)) from e
      wheel.vendored.packaging.requirements.InvalidRequirement: Expected end or semicolon (after version specifier)
          opencv-python>=3.
                       ~~~^
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for gym
  Running setup.py clean for gym
Failed to build gym
ERROR: Could not build wheels for gym, which is required to install pyproject.toml-based projects
```
I found these two related issues:
- [[Bug Report] Building wheel for gym (setup.py) ... error · Issue #3202 · openai/gym (github.com)](https://github.com/openai/gym/issues/3202)
- [Insufficient Requirements in Documentation to Install (Specifically Gym 0.21.0) · Issue #23 · netneurolab/conn2res (github.com)](https://github.com/netneurolab/conn2res/issues/23)

And then I checked the installed `wheel` on  Ubuntu 20.04 and Ubuntu 22.04:
Ubuntu 20.04 focal
```
(venv) pip list | grep wheel
wheel                    0.34.2
```

Ubuntu 22.04 jammy
```
(venv) pip list | grep wheel
wheel                    0.40.0
```

So I added a line to `install-pythonpackages.sh` and the issue was resolved.
```bash
$PYTHON -m pip install wheel==0.38.4
```
