### PR TITLE
Typo in logging message when blocking incoming connections.

### DIFF
--- a/cyberbattle/simulation/actions.py
+++ b/cyberbattle/simulation/actions.py
@@ -567,7 +567,7 @@ class AgentActions:
             return ActionResult(reward=Penalty.BLOCKED_BY_LOCAL_FIREWALL, outcome=None)
 
         if not self.__is_passing_firewall_rules(target_node.firewall.incoming, port_name):
-            logger.info(f"BLOCKED TRAFFIC: target node '{target_node_id}'" + f" is blocking outgoing traffic on port '{port_name}'")
+            logger.info(f"BLOCKED TRAFFIC: target node '{target_node_id}'" + f" is blocking incoming traffic on port '{port_name}'")
             return ActionResult(reward=Penalty.BLOCKED_BY_REMOTE_FIREWALL, outcome=None)
 
         target_node_is_listening = port_name in [i.name for i in target_node.services]


### PR DESCRIPTION
The logging message should read "incoming" instead of "outgoing".