### PR TITLE
Remove orphaned nvidia-*-cu11 pins after torch 2.13.0 upgrade

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -97,10 +97,6 @@ nbformat==5.9.2
 nest-asyncio==1.5.8
 notebook==7.5.7
 notebook-shim==0.2.4
-nvidia-cublas-cu11==11.10.3.66
-nvidia-cuda-nvrtc-cu11==11.7.99
-nvidia-cuda-runtime-cu11==11.7.99
-nvidia-cudnn-cu11==8.5.0.96
 overrides==7.4.0
 packaging==23.2
 pandocfilters==1.5.0


### PR DESCRIPTION
## Summary

Follow-up cleanup after the torch 2.13.0 upgrade (#186). Removes four explicitly-pinned CUDA 11 packages that are no longer needed by any dependency.

## Why

`torch==2.13.0` uses the CUDA 13 (`cu13`) wheel stack (`nvidia-cublas`, `nvidia-cudnn-cu13`, etc.). The following `cu11` pins in `requirements.dev.txt` were left over from a much older torch and are now dead weight — pip/uv installs them as explicit top-level requirements even though nothing depends on them:

- `nvidia-cublas-cu11==11.10.3.66`
- `nvidia-cuda-nvrtc-cu11==11.7.99`
- `nvidia-cuda-runtime-cu11==11.7.99`
- `nvidia-cudnn-cu11==8.5.0.96`

Removing them avoids installing ~1.5 GB of unused CUDA 11 libraries alongside the current CUDA 13 stack.

## Verification

- Full requirements resolve cleanly under uv + Python 3.10 (185 packages, down from 189; no `cu11` packages remain).
- Docker image builds successfully with torch 2.13.0.
- A baseline DQL training + eval run completes inside the image (`python -m cyberbattle.agents.baseline.run ... --chain_size=4`), with `torch 2.13.0+cu130` loaded and sensible converging reward curves — confirming the torch 2.13.0 upgrade works for training.